### PR TITLE
changed baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8 
+FROM java:8 
 
 # Install maven
 RUN apt-get update
@@ -16,4 +16,4 @@ ADD src /code/src
 RUN ["mvn", "package"]
 
 EXPOSE 4567
-CMD ["java", "-jar", "target/sparkexample-jar-with-dependencies.jar"]
+CMD ["/usr/lib/jvm/java-8-openjdk-amd64/bin/java", "-jar", "target/sparkexample-jar-with-dependencies.jar"]


### PR DESCRIPTION
- changed baseimage to the official one, because "dockerfile/" will get deprecated
- the CMD needs to point to java8 directly, because the java command defaults to java 7 after maven gets installed (there might be a different fix for that) /ping @luebken 